### PR TITLE
feat: re-run single JUnit5 parameterized test invocation via uniqueId

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
@@ -17,6 +17,7 @@ import com.microsoft.java.test.plugin.model.TestLevel;
 import com.microsoft.java.test.plugin.util.JUnitPlugin;
 import com.microsoft.java.test.plugin.util.TestSearchUtils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -182,7 +183,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
             }
             arguments.add(method.getDeclaringType().getFullyQualifiedName() + ':' + testName);
 
-            if (this.args.uniqueId != null && !this.args.uniqueId.isBlank()) {
+            if (StringUtils.isNotBlank(this.args.uniqueId)) {
                 arguments.add("-uniqueId");
                 arguments.add(this.args.uniqueId);
             }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
@@ -181,6 +181,11 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
                 }
             }
             arguments.add(method.getDeclaringType().getFullyQualifiedName() + ':' + testName);
+
+            if (this.args.uniqueId != null && !this.args.uniqueId.isBlank()) {
+                arguments.add("-uniqueId");
+                arguments.add(this.args.uniqueId);
+            }
         }
     }
 

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
@@ -204,5 +204,6 @@ public class JUnitLaunchUtils {
         public TestLevel testLevel;
         public TestKind testKind;
         public String[] testNames;
+        public String uniqueId;
     }
 }

--- a/src/controller/testController.ts
+++ b/src/controller/testController.ts
@@ -296,8 +296,9 @@ function handleInvocationRerun(testItems: TestItem[]): boolean {
 
     // always remove uniqueIds from non-invocation items, since they would have been set for a past run
     testItems.forEach((item: TestItem) => {
-        if (dataCache.get(item) && dataCache.get(item)!.testLevel !== TestLevel.Invocation) {
-            dataCache.get(item)!.uniqueId = undefined;
+        const itemData: ITestItemData | undefined = dataCache.get(item);
+        if (itemData && itemData.testLevel !== TestLevel.Invocation) {
+            itemData.uniqueId = undefined;
         }
     });
 
@@ -306,7 +307,7 @@ function handleInvocationRerun(testItems: TestItem[]): boolean {
         // we run the parent method, but with restriction to the single invocation parameter-set
         const invocation: TestItem = testItems[0];
         if (!invocation.parent || !dataCache.get(invocation.parent)) {
-            sendError(new Error('Trying to re-run a single test invocation, but could not find a corresponding Method-level parent item with data.'));
+            sendError(new Error('Trying to re-run a single test invocation, but could not find a corresponding method-level parent item with data.'));
             testItems.length = 0;
             return isInvocationRerun;
         }

--- a/src/controller/testItemDataCache.ts
+++ b/src/controller/testItemDataCache.ts
@@ -33,4 +33,5 @@ export interface ITestItemData {
     projectName: string;
     testLevel: TestLevel;
     testKind: TestKind;
+    uniqueId?: string;
 }

--- a/src/controller/utils.ts
+++ b/src/controller/utils.ts
@@ -105,7 +105,7 @@ export function synchronizeItemsRecursively(parent: TestItem, childrenData: IJav
     }
 }
 
-function updateOrCreateTestItem(parent: TestItem, childData: IJavaTestItem): TestItem {
+export function updateOrCreateTestItem(parent: TestItem, childData: IJavaTestItem): TestItem {
     let childItem: TestItem | undefined = parent.children.get(childData.id);
     if (childItem) {
         updateTestItem(childItem, childData);

--- a/src/controller/utils.ts
+++ b/src/controller/utils.ts
@@ -144,7 +144,9 @@ export function createTestItem(metaInfo: IJavaTestItem, parent?: TestItem): Test
         metaInfo.uri ? Uri.parse(metaInfo.uri) : undefined,
     );
     item.range = asRange(metaInfo.range);
-    if (metaInfo.testLevel !== TestLevel.Invocation) {
+    if (metaInfo.testLevel !== TestLevel.Invocation
+        // invocations of JUnit5 parameterized tests can be run again using their uniqueId:
+        || (metaInfo.testKind === TestKind.JUnit5 && metaInfo.uniqueId)) {
         item.tags = [runnableTag];
         dataCache.set(item, {
             jdtHandler: metaInfo.jdtHandler,
@@ -152,6 +154,7 @@ export function createTestItem(metaInfo: IJavaTestItem, parent?: TestItem): Test
             projectName: metaInfo.projectName,
             testLevel: metaInfo.testLevel,
             testKind: metaInfo.testKind,
+            uniqueId: metaInfo.uniqueId
         });
     }
     if (parent) {

--- a/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
+++ b/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
@@ -226,6 +226,9 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
             const parentIndex: string = result[5];
             const displayName: string = result[6].replace(/\\,/g, ',');
 
+            const uniqueId: string | undefined = this.testContext.kind === TestKind.JUnit5 ?
+                result[8]?.replace(/\\,/g, ',') : undefined;
+
             let testItem: TestItem | undefined;
             if (isDynamic) {
                 const parentInfo: ITestInfo | undefined = this.testOutputMapping.get(parentIndex);
@@ -240,10 +243,13 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
                             jdtHandler: parentData.jdtHandler,
                             fullName: parentData.fullName,
                             label: this.getTestMethodName(displayName),
-                            id: `${INVOCATION_PREFIX}${parent.id}[#${parent.children.size + 1}]`,
+                            // prefer uniqueId, as it does not change when re-running only a single invocation:
+                            id: uniqueId ? `${INVOCATION_PREFIX}${uniqueId}`
+                                : `${INVOCATION_PREFIX}${parent.id}[#${parent.children.size + 1}]`,
                             projectName: parentData.projectName,
                             testKind: parentData.testKind,
                             testLevel: TestLevel.Invocation,
+                            uniqueId
                         }, parent);
                     }
                 }

--- a/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
+++ b/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
@@ -4,7 +4,7 @@
 import { Location, MarkdownString, TestItem, TestMessage } from 'vscode';
 import { INVOCATION_PREFIX } from '../../constants';
 import { dataCache, ITestItemData } from '../../controller/testItemDataCache';
-import { createTestItem } from '../../controller/utils';
+import { createTestItem, updateOrCreateTestItem } from '../../controller/utils';
 import { IJavaTestItem, IRunTestContext, TestKind, TestLevel } from '../../types';
 import { RunnerResultAnalyzer } from '../baseRunner/RunnerResultAnalyzer';
 import { findTestLocation, setTestState, TestResultState } from '../utils';
@@ -236,7 +236,7 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
                 if (parent) {
                     const parentData: ITestItemData | undefined = dataCache.get(parent);
                     if (parentData?.testLevel === TestLevel.Method) {
-                        testItem = createTestItem({
+                        testItem = updateOrCreateTestItem(parent, {
                             children: [],
                             uri: parent.uri?.toString(),
                             range: parent.range,
@@ -250,7 +250,7 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
                             testKind: parentData.testKind,
                             testLevel: TestLevel.Invocation,
                             uniqueId
-                        }, parent);
+                        });
                     }
                 }
             } else {

--- a/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
+++ b/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
@@ -225,7 +225,6 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
             const isDynamic: boolean = result[4] === 'true';
             const parentIndex: string = result[5];
             const displayName: string = result[6].replace(/\\,/g, ',');
-
             const uniqueId: string | undefined = this.testContext.kind === TestKind.JUnit5 ?
                 result[8]?.replace(/\\,/g, ',') : undefined;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,12 @@ export interface IJavaTestItem {
     testKind: TestKind;
     testLevel: TestLevel;
     /**
+     * Identifies a single invocation of a parameterized test.
+     * Invocations for which a re-run is possible store their own uniqueId which is provided as part of the result.
+     * Methods may store it in order to specify a certain parameter-set to be used when running again.
+     */
+    uniqueId?: string;
+    /**
      * Optional fields for projects
      */
     natureIds?: string[];

--- a/src/utils/launchUtils.ts
+++ b/src/utils/launchUtils.ts
@@ -81,11 +81,17 @@ async function getLaunchArguments(testContext: IRunTestContext): Promise<IJUnitL
         sendError(error);
         throw error;
     }
+
+    // optional uniqueId in case we are re-running only a single invocation:
+    const uniqueId: string | undefined = testContext.testItems.length === 1 ?
+        dataCache.get(testContext.testItems[0])?.uniqueId : undefined;
+
     return await resolveJUnitLaunchArguments(
         testContext.projectName,
         testLevel,
         testContext.kind,
         getTestNames(testContext),
+        uniqueId
     );
 }
 
@@ -107,13 +113,14 @@ function getTestNames(testContext: IRunTestContext): string[] {
     }).filter(Boolean) as string[];
 }
 
-async function resolveJUnitLaunchArguments(projectName: string, testLevel: TestLevel, testKind: TestKind, testNames: string[]): Promise<IJUnitLaunchArguments> {
+async function resolveJUnitLaunchArguments(projectName: string, testLevel: TestLevel, testKind: TestKind, testNames: string[], uniqueId: string | undefined): Promise<IJUnitLaunchArguments> {
     const argument: IJUnitLaunchArguments | undefined = await executeJavaLanguageServerCommand<IJUnitLaunchArguments>(
         JavaTestRunnerDelegateCommands.RESOLVE_JUNIT_ARGUMENT, JSON.stringify({
             projectName,
             testLevel,
             testKind,
             testNames,
+            uniqueId
         }),
     );
 


### PR DESCRIPTION
Support for re-running/debugging a parameterized JUnit5 test with a single set of parameters, similar to the corresponding eclipse feature:
![vscode_rerun_possible](https://user-images.githubusercontent.com/53265832/163722283-27ce0097-8b3a-44f0-8d40-8238732f6823.png)

As in Eclipse, only the selected invocation is visible in the test-explorer after the re-run:
![vscode_after_rerun](https://user-images.githubusercontent.com/53265832/163722352-664acb50-f5d7-44b2-8c3e-0806ea9e8484.png)

While e.g. the VSCode Python extension updates only the TestItem of the executed parameter-set, and retains info on all other TestItems, this would require more changes in vscode-java-test.

https://github.com/microsoft/vscode-java-test/issues/1408